### PR TITLE
🔒 Remove insecure environment variable fallback for API key

### DIFF
--- a/constants/api-key-context.tsx
+++ b/constants/api-key-context.tsx
@@ -16,7 +16,7 @@ interface ApiKeyProviderProps {
 }
 
 export function ApiKeyProvider({ children }: ApiKeyProviderProps) {
-  const [apiKey, setApiKeyState] = useState<string>(process.env.JULES_API_KEY || process.env.EXPO_PUBLIC_JULES_API_KEY || '');
+  const [apiKey, setApiKeyState] = useState<string>('');
   const [isLoaded, setIsLoaded] = useState(false);
 
   // Load API key on mount


### PR DESCRIPTION
🎯 **What:** Removed the environment variable fallbacks (`process.env.JULES_API_KEY` and `process.env.EXPO_PUBLIC_JULES_API_KEY`) from the `apiKey` initialization in `constants/api-key-context.tsx`.

⚠️ **Risk:** Directly passing environment variables into the initial state of the API key exposes the key directly on the client and in the source bundles, allowing unauthorized parties to access and misuse it.

🛡️ **Solution:** Replaced the insecure `process.env` fallback with an empty string (`''`). The component already effectively handles loading the saved key dynamically via `SecureStore` when the component mounts, so this removes the vulnerability without breaking functionality.

---
*PR created automatically by Jules for task [12295360081163404340](https://jules.google.com/task/12295360081163404340) started by @linkalls*